### PR TITLE
Focus on input on page load

### DIFF
--- a/2auth/app/views/index.pug
+++ b/2auth/app/views/index.pug
@@ -10,7 +10,7 @@ block content
   p Enter your email address to get access 
   form(name="sendmail", method="post")
    div.input
-    input(type="text", name="mailbox")
+    input(type="text", name="mailbox", autofocus)
     span.label @#{domain}
     p
    div.action


### PR DESCRIPTION
Focus on the text field immediately after loading the page. Thanks to this, you can enter your email immediately after opening the page.